### PR TITLE
When user denies access, returns 500 error complaining about no oauth_verifier

### DIFF
--- a/lib/Dancer/Plugin/Auth/Twitter.pm
+++ b/lib/Dancer/Plugin/Auth/Twitter.pm
@@ -68,6 +68,9 @@ get '/auth/twitter/callback' => sub {
 
     debug "in callback...";
 
+    # A user denying access should be considered a failure
+    return redirect $callback_fail if (params->{'denied'});
+
     if (   !session('request_token')
         || !session('request_token_secret')
         || !params->{'oauth_verifier'})


### PR DESCRIPTION
I added a conditional at the beginning of the callback handler that redirects to the fail handler when ever the user denies the application access to their Twitter account.
