### PR TITLE
Support for both authentication and authorization process

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Dancer-Plugin-Auth-Twitter
 
+0.10	2011-04-30
+	
+	[ Simon Elsbrock ]
+	* support for both authentication and authorization method
+
 0.02	2011-01-17
 	
 	[ Yanick Champoux ]

--- a/lib/Dancer/Plugin/Auth/Twitter.pm
+++ b/lib/Dancer/Plugin/Auth/Twitter.pm
@@ -7,7 +7,7 @@ use Dancer::Plugin;
 use Carp 'croak';
 use Net::Twitter;
 
-our $VERSION = 0.02;
+our $VERSION = 0.10;
 
 # Net::Twitter singleton, accessible via 'twitter'
 my $_twitter;
@@ -45,13 +45,32 @@ register 'auth_twitter_init' => sub {
 
 };
 
+# define a route handler that bounces to the OAuth authorization process
+register 'auth_twitter_authorize_url' => sub {
+    if (not defined twitter) {
+        croak "auth_twitter_init must be called first";
+    }
+
+    my $uri = twitter->get_authorization_url( 
+        'callback' => $callback_url
+    );
+
+    session request_token        => twitter->request_token;
+    session request_token_secret => twitter->request_token_secret;
+    session access_token         => '';
+    session access_token_secret  => '';
+
+    debug "auth URL : $uri";
+    return $uri;
+};
+
 # define a route handler that bounces to the OAuth authentication process
 register 'auth_twitter_authenticate_url' => sub {
     if (not defined twitter) {
         croak "auth_twitter_init must be called first";
     }
 
-    my $uri = twitter->get_authorization_url( 
+    my $uri = twitter->get_authentication_url(
         'callback' => $callback_url
     );
 
@@ -211,9 +230,9 @@ This function should be called before your route handlers, in order to
 initialize the underlying L<Net::Twitter> object. It will read your
 configuration and create a new L<Net::Twitter> instance.
 
-=head2 auth_twitter_authenticate_url
+=head2 auth_twitter_authorize_url
 
-This function returns an authenticate URI for redirecting unauthenticated users.
+This function returns an authorize URI for redirecting unauthenticated users.
 You should use this in a before filter like the following:
 
     before sub {
@@ -221,12 +240,21 @@ You should use this in a before filter like the following:
         return if request->path =~ m{/auth/twitter/callback};
     
         if (not session('twitter_user')) {
-            redirect auth_twitter_authenticate_url();
+            redirect auth_twitter_authorize_url();
         }
     };
 
 When the user authenticate with Twitter's OAuth interface, she's going to be
 bounced back to C</auth/twitter/callback>.
+
+=head2 auth_twitter_authenticate_url
+
+Similar to auth_twitter_authorize_url, but this function instead returns an
+authenticate instead of authorize URI for redirecting unauthenticated users,
+which results in a slightly different behaviour.
+
+See L<https://dev.twitter.com/pages/sign_in_with_twitter|here> to learn about
+the differences.
 
 =head1 ROUTE HANDLERS
 


### PR DESCRIPTION
The [Twitter documentation](https://dev.twitter.com/pages/sign_in_with_twitter) describes two ways of authenticating an account:
- using the authentication method: the user is asked to grant the application access to her account without checking whether this has already been done
- using the authorization method: the user is asked to grant the application access to her account once only (this is referred to as "sign-in with twitter")

This commit adds the "authenticate" methods to use the slightly different process flow supported by Twitter.

Up to now, the package unfortunately used the terminology in the wrong way - the auth_twitter_authenticate_url returned an authorization URI, but should instead return an authentication URI. Thus, I have changed the terminology of the existing method and added a second method called auth_twitter_authorize_url, which will of course return the authorization URI. Both methods are supported by the underlying Net::Twitter package.

Altough this commit is backwards compatible, it will change behaviour. Not sure whether this is okay or not - please tell me. I thought it would be better to get the terminology right.
